### PR TITLE
Enhancement: Enable `self_static_accessor` fixer

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -39,6 +39,7 @@ return $config
         'phpdoc_summary' => true,
         'psr_autoloading' => true,
         'return_type_declaration' => ['space_before' => 'none'],
+        'self_static_accessor' => true,
         'single_blank_line_before_namespace' => true,
         'single_quote' => true,
         'space_after_semicolon' => true,


### PR DESCRIPTION
This pull request

- [x] enables the `self_static_accessor` fixer
- [ ] runs `composer phpcs:fix`

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.15.1/doc/rules/class_notation/self_static_accessor.rst.
