### PR TITLE
Removed accidental space from top readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ echo DataType::List->serialize([
         [
             ['expire', new DateTimeImmutable('2023-04-14 20:32:08')],
             ['path', '/'],
-            [ 'max-age', 2500],
+            ['max-age', 2500],
             ['secure', true],
             ['httponly', true],
             ['samesite', Token::fromString('lax')],


### PR DESCRIPTION
It just looked weird to me having that space there and not for the others