### PR TITLE
Introduce the StructuredFieldAccess interface

### DIFF
--- a/src/Dictionary.php
+++ b/src/Dictionary.php
@@ -55,7 +55,7 @@ final class Dictionary implements MemberOrderedMap
      */
     private static function filterMember(mixed $member): object
     {
-        if ($member instanceof StructuredFieldAccess) {
+        if ($member instanceof StructuredFieldProvider) {
             $member = $member->toStructuredField();
         }
 
@@ -103,7 +103,7 @@ final class Dictionary implements MemberOrderedMap
          * @return ParameterAccess&(MemberList|ValueAccess)
          */
         $converter = function (mixed $pair): StructuredField {
-            if ($pair instanceof StructuredFieldAccess) {
+            if ($pair instanceof StructuredFieldProvider) {
                 $pair = $pair->toStructuredField();
             }
 
@@ -300,7 +300,7 @@ final class Dictionary implements MemberOrderedMap
     /**
      * @param SfMember|SfMemberInput $member
      */
-    public function add(string $key, iterable|StructuredFieldAccess|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member): static
+    public function add(string $key, iterable|StructuredFieldProvider|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member): static
     {
         $members = $this->members;
         $members[MapKey::from($key)->value] = self::filterMember($member);
@@ -363,7 +363,7 @@ final class Dictionary implements MemberOrderedMap
      */
     public function append(
         string $key,
-        iterable|StructuredFieldAccess|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
+        iterable|StructuredFieldProvider|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
     ): static {
         $members = $this->members;
         unset($members[$key]);
@@ -376,7 +376,7 @@ final class Dictionary implements MemberOrderedMap
      */
     public function prepend(
         string $key,
-        iterable|StructuredFieldAccess|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
+        iterable|StructuredFieldProvider|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
     ): static {
         $members = $this->members;
         unset($members[$key]);

--- a/src/Dictionary.php
+++ b/src/Dictionary.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bakame\Http\StructuredFields;
 
 use ArrayAccess;
+use Closure;
 use DateTimeInterface;
 use Iterator;
 use Stringable;
@@ -18,6 +19,8 @@ use function is_array;
 use function is_int;
 use function is_iterable;
 use function is_string;
+
+use const ARRAY_FILTER_USE_BOTH;
 
 /**
  * @see https://www.rfc-editor.org/rfc/rfc9651.html#section-3.2
@@ -494,5 +497,52 @@ final class Dictionary implements MemberOrderedMap
     public function offsetSet(mixed $offset, mixed $value): void
     {
         throw new ForbiddenOperation(self::class.' instance can not be updated using '.ArrayAccess::class.' methods.');
+    }
+
+    /**
+     * @param Closure(SfMember, string): TMap $callback
+     *
+     * @template TMap
+     *
+     * @return Iterator<TMap>
+     */
+    public function map(Closure $callback): Iterator
+    {
+        /**
+         * @var string $offset
+         * @var SfMember $member
+         */
+        foreach ($this as $offset => $member) {
+            yield ($callback)($member, $offset);
+        }
+    }
+
+    /**
+     * @param Closure(TInitial|null, SfMember, string=): TInitial $callback
+     * @param TInitial|null $initial
+     *
+     * @template TInitial
+     *
+     * @return TInitial|null
+     */
+    public function reduce(Closure $callback, mixed $initial = null): mixed
+    {
+        /**
+         * @var string $offset
+         * @var SfMember $record
+         */
+        foreach ($this as $offset => $record) {
+            $initial = $callback($initial, $record, $offset);
+        }
+
+        return $initial;
+    }
+
+    /**
+     * @param Closure(SfMember, string): bool $callback
+     */
+    public function filter(Closure $callback): self
+    {
+        return new self(array_filter($this->members, $callback, ARRAY_FILTER_USE_BOTH));
     }
 }

--- a/src/Dictionary.php
+++ b/src/Dictionary.php
@@ -52,6 +52,10 @@ final class Dictionary implements MemberOrderedMap
      */
     private static function filterMember(mixed $member): object
     {
+        if ($member instanceof StructuredFieldAccess) {
+            $member = $member->toStructuredField();
+        }
+
         return match (true) {
             $member instanceof ParameterAccess && ($member instanceof MemberList || $member instanceof ValueAccess) => $member,
             $member instanceof StructuredField => throw new InvalidArgument('An instance of "'.$member::class.'" can not be a member of "'.self::class.'".'),
@@ -96,6 +100,10 @@ final class Dictionary implements MemberOrderedMap
          * @return ParameterAccess&(MemberList|ValueAccess)
          */
         $converter = function (mixed $pair): StructuredField {
+            if ($pair instanceof StructuredFieldAccess) {
+                $pair = $pair->toStructuredField();
+            }
+
             if ($pair instanceof ParameterAccess && ($pair instanceof MemberList || $pair instanceof ValueAccess)) {
                 return $pair;
             }
@@ -289,7 +297,7 @@ final class Dictionary implements MemberOrderedMap
     /**
      * @param SfMember|SfMemberInput $member
      */
-    public function add(string $key, iterable|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member): static
+    public function add(string $key, iterable|StructuredFieldAccess|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member): static
     {
         $members = $this->members;
         $members[MapKey::from($key)->value] = self::filterMember($member);
@@ -352,7 +360,7 @@ final class Dictionary implements MemberOrderedMap
      */
     public function append(
         string $key,
-        iterable|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
+        iterable|StructuredFieldAccess|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
     ): static {
         $members = $this->members;
         unset($members[$key]);
@@ -365,7 +373,7 @@ final class Dictionary implements MemberOrderedMap
      */
     public function prepend(
         string $key,
-        iterable|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
+        iterable|StructuredFieldAccess|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
     ): static {
         $members = $this->members;
         unset($members[$key]);

--- a/src/Ietf.php
+++ b/src/Ietf.php
@@ -37,11 +37,15 @@ enum Ietf: string
         };
     }
 
-    public function supports(mixed $type): bool
+    public function supports(mixed $value): bool
     {
-        if ($type instanceof StructuredField) {
+        if ($value instanceof StructuredFieldProvider) {
+            $value = $value->toStructuredField();
+        }
+
+        if ($value instanceof StructuredField) {
             try {
-                $type->toHttpValue($this);
+                $value->toHttpValue($this);
 
                 return true;
             } catch (Throwable) {
@@ -49,11 +53,11 @@ enum Ietf: string
             }
         }
 
-        if (!$type instanceof Type) {
-            $type = Type::tryFromVariable($type);
+        if (!$value instanceof Type) {
+            $value = Type::tryFromVariable($value);
         }
 
-        return match ($type) {
+        return match ($value) {
             null => false,
             Type::DisplayString,
             Type::Date => self::Rfc8941 !== $this,

--- a/src/InnerList.php
+++ b/src/InnerList.php
@@ -53,7 +53,7 @@ final class InnerList implements MemberList, ParameterAccess
      */
     private function filterMember(mixed $member): object
     {
-        if ($member instanceof StructuredFieldAccess) {
+        if ($member instanceof StructuredFieldProvider) {
             $member = $member->toStructuredField();
         }
 
@@ -114,7 +114,7 @@ final class InnerList implements MemberList, ParameterAccess
      * Returns a new instance.
      */
     public static function new(
-        StructuredFieldAccess|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool ...$members
+        StructuredFieldProvider|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool ...$members
     ): self {
         return new self($members, Parameters::new());
     }
@@ -256,12 +256,12 @@ final class InnerList implements MemberList, ParameterAccess
      * Inserts members at the beginning of the list.
      */
     public function unshift(
-        StructuredFieldAccess|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool ...$members
+        StructuredFieldProvider|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool ...$members
     ): static {
         $membersToAdd = array_reduce(
             $members,
             function (array $carry, $member) {
-                if ($member instanceof StructuredFieldAccess) {
+                if ($member instanceof StructuredFieldProvider) {
                     $member = $member->toStructuredField();
                 }
 
@@ -280,12 +280,12 @@ final class InnerList implements MemberList, ParameterAccess
      * Inserts members at the end of the list.
      */
     public function push(
-        StructuredFieldAccess|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool ...$members
+        StructuredFieldProvider|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool ...$members
     ): static {
         $membersToAdd = array_reduce(
             $members,
             function (array $carry, $member) {
-                if ($member instanceof StructuredFieldAccess) {
+                if ($member instanceof StructuredFieldProvider) {
                     $member = $member->toStructuredField();
                 }
 
@@ -307,7 +307,7 @@ final class InnerList implements MemberList, ParameterAccess
      */
     public function insert(
         int $key,
-        StructuredFieldAccess|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool ...$members
+        StructuredFieldProvider|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool ...$members
     ): static {
         $offset = $this->filterIndex($key) ?? throw InvalidOffset::dueToIndexNotFound($key);
 
@@ -325,7 +325,7 @@ final class InnerList implements MemberList, ParameterAccess
 
     public function replace(
         int $key,
-        StructuredFieldAccess|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
+        StructuredFieldProvider|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
     ): static {
         $offset = $this->filterIndex($key) ?? throw InvalidOffset::dueToIndexNotFound($key);
         $member = self::filterMember($member);
@@ -439,21 +439,21 @@ final class InnerList implements MemberList, ParameterAccess
         return ($this->parameters->toHttpValue() === $parameters->toHttpValue()) ? $this : new self($this->members, $parameters);
     }
 
-    public function addParameter(string $key, StructuredFieldAccess|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member): static
+    public function addParameter(string $key, StructuredFieldProvider|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member): static
     {
         return $this->withParameters($this->parameters()->add($key, $member));
     }
 
     public function prependParameter(
         string $key,
-        StructuredFieldAccess|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
+        StructuredFieldProvider|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
     ): static {
         return $this->withParameters($this->parameters()->prepend($key, $member));
     }
 
     public function appendParameter(
         string $key,
-        StructuredFieldAccess|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
+        StructuredFieldProvider|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
     ): static {
         return $this->withParameters($this->parameters()->append($key, $member));
     }

--- a/src/Item.php
+++ b/src/Item.php
@@ -337,21 +337,21 @@ final class Item implements ParameterAccess, ValueAccess
 
     public function addParameter(
         string $key,
-        StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
+        StructuredFieldAccess|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
     ): static {
         return $this->withParameters($this->parameters()->add($key, $member));
     }
 
     public function prependParameter(
         string $key,
-        StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
+        StructuredFieldAccess|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
     ): static {
         return $this->withParameters($this->parameters()->prepend($key, $member));
     }
 
     public function appendParameter(
         string $key,
-        StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
+        StructuredFieldAccess|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
     ): static {
         return $this->withParameters($this->parameters()->append($key, $member));
     }

--- a/src/Item.php
+++ b/src/Item.php
@@ -337,21 +337,21 @@ final class Item implements ParameterAccess, ValueAccess
 
     public function addParameter(
         string $key,
-        StructuredFieldAccess|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
+        StructuredFieldProvider|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
     ): static {
         return $this->withParameters($this->parameters()->add($key, $member));
     }
 
     public function prependParameter(
         string $key,
-        StructuredFieldAccess|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
+        StructuredFieldProvider|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
     ): static {
         return $this->withParameters($this->parameters()->prepend($key, $member));
     }
 
     public function appendParameter(
         string $key,
-        StructuredFieldAccess|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
+        StructuredFieldProvider|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
     ): static {
         return $this->withParameters($this->parameters()->append($key, $member));
     }

--- a/src/MemberContainer.php
+++ b/src/MemberContainer.php
@@ -6,6 +6,7 @@ namespace Bakame\Http\StructuredFields;
 
 use ArrayAccess;
 use Countable;
+use Iterator;
 use IteratorAggregate;
 
 /**
@@ -13,6 +14,10 @@ use IteratorAggregate;
  * @template TValue of StructuredField
  * @template-extends ArrayAccess<TKey, TValue>
  * @template-extends IteratorAggregate<TKey, TValue>
+ *
+ * @method Iterator map(callable $callback) Run a map over each of the members.
+ * @method static filter(callable $callback) Run a fillter over each of the members.
+ * @method mixed reduce(callable $callback) Reduce the collection to a single value.
  */
 interface MemberContainer extends ArrayAccess, Countable, IteratorAggregate, StructuredField
 {

--- a/src/OuterList.php
+++ b/src/OuterList.php
@@ -45,7 +45,7 @@ final class OuterList implements MemberList
      * @param SfMember|SfMemberInput ...$members
      */
     private function __construct(
-        iterable|StructuredFieldAccess|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool ...$members
+        iterable|StructuredFieldProvider|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool ...$members
     ) {
         $this->members = array_map($this->filterMember(...), array_values([...$members]));
     }
@@ -57,7 +57,7 @@ final class OuterList implements MemberList
      */
     private function filterMember(mixed $member): object
     {
-        if ($member instanceof StructuredFieldAccess) {
+        if ($member instanceof StructuredFieldProvider) {
             $member = $member->toStructuredField();
         }
 
@@ -95,7 +95,7 @@ final class OuterList implements MemberList
          * @return ParameterAccess&(MemberList|ValueAccess)
          */
         $converter = function (mixed $pair): StructuredField {
-            if ($pair instanceof StructuredFieldAccess) {
+            if ($pair instanceof StructuredFieldProvider) {
                 $pair = $pair->toStructuredField();
             }
 
@@ -133,7 +133,7 @@ final class OuterList implements MemberList
     /**
      * @param SfMember|SfMemberInput ...$members
      */
-    public static function new(iterable|StructuredFieldAccess|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool ...$members): self
+    public static function new(iterable|StructuredFieldProvider|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool ...$members): self
     {
         return new self(...$members);
     }
@@ -241,12 +241,12 @@ final class OuterList implements MemberList
      * @param SfMember|SfMemberInput ...$members
      */
     public function unshift(
-        iterable|StructuredFieldAccess|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool ...$members
+        iterable|StructuredFieldProvider|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool ...$members
     ): static {
         $membersToAdd = array_reduce(
             $members,
             function (array $carry, $member) {
-                if ($member instanceof StructuredFieldAccess) {
+                if ($member instanceof StructuredFieldProvider) {
                     $member = $member->toStructuredField();
                 }
 
@@ -267,12 +267,12 @@ final class OuterList implements MemberList
      * @param SfMember|SfMemberInput ...$members
      */
     public function push(
-        iterable|StructuredFieldAccess|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool ...$members
+        iterable|StructuredFieldProvider|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool ...$members
     ): static {
         $membersToAdd = array_reduce(
             $members,
             function (array $carry, $member) {
-                if ($member instanceof StructuredFieldAccess) {
+                if ($member instanceof StructuredFieldProvider) {
                     $member = $member->toStructuredField();
                 }
 
@@ -296,7 +296,7 @@ final class OuterList implements MemberList
      */
     public function insert(
         int $key,
-        iterable|StructuredFieldAccess|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool ...$members
+        iterable|StructuredFieldProvider|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool ...$members
     ): static {
         $offset = $this->filterIndex($key) ?? throw InvalidOffset::dueToIndexNotFound($key);
 
@@ -317,7 +317,7 @@ final class OuterList implements MemberList
      */
     public function replace(
         int $key,
-        iterable|StructuredFieldAccess|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
+        iterable|StructuredFieldProvider|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
     ): static {
         $offset = $this->filterIndex($key) ?? throw InvalidOffset::dueToIndexNotFound($key);
         $member = self::filterMember($member);

--- a/src/OuterList.php
+++ b/src/OuterList.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bakame\Http\StructuredFields;
 
 use ArrayAccess;
+use Closure;
 use DateTimeInterface;
 use Iterator;
 use Stringable;
@@ -21,6 +22,7 @@ use function is_array;
 use function is_int;
 use function is_iterable;
 
+use const ARRAY_FILTER_USE_BOTH;
 use const ARRAY_FILTER_USE_KEY;
 
 /**
@@ -374,5 +376,52 @@ final class OuterList implements MemberList
     public function offsetSet(mixed $offset, mixed $value): void
     {
         throw new ForbiddenOperation(self::class.' instance can not be updated using '.ArrayAccess::class.' methods.');
+    }
+
+    /**
+     * @param Closure(SfItem, string): TMap $callback
+     *
+     * @template TMap
+     *
+     * @return Iterator<TMap>
+     */
+    public function map(Closure $callback): Iterator
+    {
+        /**
+         * @var string $offset
+         * @var SfItem $member
+         */
+        foreach ($this as $offset => $member) {
+            yield ($callback)($member, $offset);
+        }
+    }
+
+    /**
+     * @param Closure(TInitial|null, SfItem, string=): TInitial $callback
+     * @param TInitial|null $initial
+     *
+     * @template TInitial
+     *
+     * @return TInitial|null
+     */
+    public function reduce(Closure $callback, mixed $initial = null): mixed
+    {
+        /**
+         * @var string $offset
+         * @var SfItem $record
+         */
+        foreach ($this as $offset => $record) {
+            $initial = $callback($initial, $record, $offset);
+        }
+
+        return $initial;
+    }
+
+    /**
+     * @param Closure(SfMember, int): bool $callback
+     */
+    public function filter(Closure $callback): self
+    {
+        return new self(...array_filter($this->members, $callback, ARRAY_FILTER_USE_BOTH));
     }
 }

--- a/src/Parameters.php
+++ b/src/Parameters.php
@@ -50,6 +50,10 @@ final class Parameters implements MemberOrderedMap
      */
     private static function filterMember(mixed $member): object
     {
+        if ($member instanceof StructuredFieldAccess) {
+            $member = $member->toStructuredField();
+        }
+
         return match (true) {
             $member instanceof ParameterAccess && $member instanceof ValueAccess => $member->parameters()->hasNoMembers() ? $member : throw new InvalidArgument('The "'.$member::class.'" instance is not a Bare Item.'),
             $member instanceof StructuredField => throw new InvalidArgument('An instance of "'.$member::class.'" can not be a member of "'.self::class.'".'),
@@ -246,7 +250,7 @@ final class Parameters implements MemberOrderedMap
         return [...$this->toPairs()][$offset];
     }
 
-    public function add(string $key, StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member): static
+    public function add(string $key, StructuredFieldAccess|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member): static
     {
         $members = $this->members;
         $members[MapKey::from($key)->value] = self::filterMember($member);
@@ -306,7 +310,7 @@ final class Parameters implements MemberOrderedMap
 
     public function append(
         string $key,
-        StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
+        StructuredFieldAccess|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
     ): static {
         $members = $this->members;
         unset($members[$key]);
@@ -316,7 +320,7 @@ final class Parameters implements MemberOrderedMap
 
     public function prepend(
         string $key,
-        StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
+        StructuredFieldAccess|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
     ): static {
         $members = $this->members;
         unset($members[$key]);

--- a/src/Parameters.php
+++ b/src/Parameters.php
@@ -51,7 +51,7 @@ final class Parameters implements MemberOrderedMap
      */
     private static function filterMember(mixed $member): object
     {
-        if ($member instanceof StructuredFieldAccess) {
+        if ($member instanceof StructuredFieldProvider) {
             $member = $member->toStructuredField();
         }
 
@@ -251,7 +251,7 @@ final class Parameters implements MemberOrderedMap
         return [...$this->toPairs()][$offset];
     }
 
-    public function add(string $key, StructuredFieldAccess|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member): static
+    public function add(string $key, StructuredFieldProvider|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member): static
     {
         $members = $this->members;
         $members[MapKey::from($key)->value] = self::filterMember($member);
@@ -311,7 +311,7 @@ final class Parameters implements MemberOrderedMap
 
     public function append(
         string $key,
-        StructuredFieldAccess|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
+        StructuredFieldProvider|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
     ): static {
         $members = $this->members;
         unset($members[$key]);
@@ -321,7 +321,7 @@ final class Parameters implements MemberOrderedMap
 
     public function prepend(
         string $key,
-        StructuredFieldAccess|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
+        StructuredFieldProvider|StructuredField|Token|ByteSequence|DisplayString|DateTimeInterface|string|int|float|bool $member
     ): static {
         $members = $this->members;
         unset($members[$key]);

--- a/src/StructuredField.php
+++ b/src/StructuredField.php
@@ -11,7 +11,7 @@ use Stringable;
  * @phpstan-type SfType ByteSequence|Token|DisplayString|\DateTimeImmutable|string|int|float|bool
  * @phpstan-type SfTypeInput SfType|\DateTimeInterface
  * @phpstan-type SfItem ValueAccess&ParameterAccess
- * @phpstan-type SfItemInput SfItem|SfTypeInput|StructuredFieldAccess|StructuredField
+ * @phpstan-type SfItemInput SfItem|SfTypeInput|StructuredFieldProvider|StructuredField
  * @phpstan-type SfMember (MemberList<int, SfItem>|ValueAccess)&ParameterAccess
  * @phpstan-type SfMemberInput iterable<SfItemInput>|SfItemInput
  * @phpstan-type SfInnerListPair array{0:iterable<SfItemInput>, 1:MemberOrderedMap<string, SfItem>|iterable<array{0:string, 1:SfItemInput}>}

--- a/src/StructuredField.php
+++ b/src/StructuredField.php
@@ -9,9 +9,9 @@ use Stringable;
 
 /**
  * @phpstan-type SfType ByteSequence|Token|DisplayString|\DateTimeImmutable|string|int|float|bool
- * @phpstan-type SfTypeInput StructuredField|SfType|\DateTimeInterface
+ * @phpstan-type SfTypeInput SfType|\DateTimeInterface
  * @phpstan-type SfItem ValueAccess&ParameterAccess
- * @phpstan-type SfItemInput SfItem|SfTypeInput
+ * @phpstan-type SfItemInput SfItem|SfTypeInput|StructuredFieldAccess|StructuredField
  * @phpstan-type SfMember (MemberList<int, SfItem>|ValueAccess)&ParameterAccess
  * @phpstan-type SfMemberInput iterable<SfItemInput>|SfItemInput
  * @phpstan-type SfInnerListPair array{0:iterable<SfItemInput>, 1:MemberOrderedMap<string, SfItem>|iterable<array{0:string, 1:SfItemInput}>}

--- a/src/StructuredFieldAccess.php
+++ b/src/StructuredFieldAccess.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bakame\Http\StructuredFields;
+
+interface StructuredFieldAccess
+{
+    /**
+     * Returns an object implementing the StructuredField interface.
+     */
+    public function toStructuredField(): StructuredField;
+}

--- a/src/StructuredFieldProvider.php
+++ b/src/StructuredFieldProvider.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Bakame\Http\StructuredFields;
 
-interface StructuredFieldAccess
+interface StructuredFieldProvider
 {
     /**
      * Returns an object implementing the StructuredField interface.

--- a/src/Type.php
+++ b/src/Type.php
@@ -28,6 +28,17 @@ enum Type: string
         };
     }
 
+    public function isOneOf(mixed ...$other): bool
+    {
+        foreach ($other as $item) {
+            if ($this->equals($item)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /**
      * @throws InvalidArgument if the value can not be resolved into a supported HTTP structured field data type
      */

--- a/tests/DictionaryTest.php
+++ b/tests/DictionaryTest.php
@@ -385,7 +385,7 @@ final class DictionaryTest extends StructuredFieldTestCase
     #[Test]
     public function it_can_create_a_new_instance_using_parameters_position_modifying_methods(): void
     {
-        $instance = new class () implements StructuredFieldAccess {
+        $instance = new class () implements StructuredFieldProvider {
             public function toStructuredField(): StructuredField
             {
                 return Item::false();

--- a/tests/DictionaryTest.php
+++ b/tests/DictionaryTest.php
@@ -385,10 +385,17 @@ final class DictionaryTest extends StructuredFieldTestCase
     #[Test]
     public function it_can_create_a_new_instance_using_parameters_position_modifying_methods(): void
     {
+        $instance = new class () implements StructuredFieldAccess {
+            public function toStructuredField(): StructuredField
+            {
+                return Item::false();
+            }
+        };
+
         $instance1 = Dictionary::new();
         $instance2 = $instance1
             ->push(['a', true], ['v', ByteSequence::fromDecoded('I will be removed')], ['c', 'true'])
-            ->unshift(['b', Item::false()])
+            ->unshift(['b', $instance])
             ->replace(1, ['a', 'false'])
             ->remove(-2, 'toto')
             ->insert(1, ['d', Token::fromString('*/*')]);

--- a/tests/IetfTest.php
+++ b/tests/IetfTest.php
@@ -80,6 +80,17 @@ final class IetfTest extends TestCase
             'expectedRfc9651' => true,
         ];
 
+        yield 'structuredFieldProvider supported' => [
+            'value' => new class () implements StructuredFieldProvider {
+                public function toStructuredField(): StructuredField
+                {
+                    return Item::fromInteger(123456789);
+                }
+            },
+            'expectedRfc8941' => true,
+            'expectedRfc9651' => true,
+        ];
+
         yield  'unknown type' => [
             'value' => new SplObjectStorage(),
             'expectedRfc8941' => false,

--- a/tests/InnerListTest.php
+++ b/tests/InnerListTest.php
@@ -204,7 +204,14 @@ final class InnerListTest extends TestCase
     #[Test]
     public function it_can_create_via_with_parameters_method_a_new_object(): void
     {
-        $list = [Token::fromString('babayaga'), 'a', true];
+        $instance = new class () implements StructuredFieldAccess {
+            public function toStructuredField(): StructuredField
+            {
+                return Item::new(Token::fromString('babayaga'));
+            }
+        };
+
+        $list = [$instance, 'a', true];
         $instance1 = InnerList::fromAssociative($list, ['a' => true]);
         $instance1bis = InnerList::fromPair([$list, [['a', true]]]);
         $instance2 = $instance1->withParameters(Parameters::fromAssociative(['a' => true]));

--- a/tests/InnerListTest.php
+++ b/tests/InnerListTest.php
@@ -204,7 +204,7 @@ final class InnerListTest extends TestCase
     #[Test]
     public function it_can_create_via_with_parameters_method_a_new_object(): void
     {
-        $instance = new class () implements StructuredFieldAccess {
+        $instance = new class () implements StructuredFieldProvider {
             public function toStructuredField(): StructuredField
             {
                 return Item::new(Token::fromString('babayaga'));

--- a/tests/OuterListTest.php
+++ b/tests/OuterListTest.php
@@ -64,9 +64,16 @@ final class OuterListTest extends StructuredFieldTestCase
     #[Test]
     public function it_can_unshift_insert_and_replace(): void
     {
+        $instance = new class () implements StructuredFieldAccess {
+            public function toStructuredField(): StructuredField
+            {
+                return Item::fromInteger(42);
+            }
+        };
+
         $instance = OuterList::new()
             ->unshift(Item::fromString('42'))
-            ->push(Item::fromInteger(42))
+            ->push($instance)
             ->insert(1, Item::fromDecimal(42.0))
             ->replace(0, Item::new(ByteSequence::fromDecoded('Hello World')));
 

--- a/tests/OuterListTest.php
+++ b/tests/OuterListTest.php
@@ -64,7 +64,7 @@ final class OuterListTest extends StructuredFieldTestCase
     #[Test]
     public function it_can_unshift_insert_and_replace(): void
     {
-        $instance = new class () implements StructuredFieldAccess {
+        $instance = new class () implements StructuredFieldProvider {
             public function toStructuredField(): StructuredField
             {
                 return Item::fromInteger(42);

--- a/tests/ParametersTest.php
+++ b/tests/ParametersTest.php
@@ -99,7 +99,14 @@ final class ParametersTest extends StructuredFieldTestCase
         self::assertFalse($deletedInstance->has('boolean'));
         self::assertFalse($deletedInstance->hasPair(1));
 
-        $addedInstance = $deletedInstance->append('foobar', Item::fromString('BarBaz'));
+        $instance = new class () implements StructuredFieldAccess {
+            public function toStructuredField(): StructuredField
+            {
+                return Item::fromString('BarBaz');
+            }
+        };
+
+        $addedInstance = $deletedInstance->append('foobar', $instance);
         self::assertSame($addedInstance, $addedInstance->append('foobar', Item::new('BarBaz')));
         self::assertTrue($addedInstance->hasPair(1));
         self::assertFalse($addedInstance->hasPair(3, 23));

--- a/tests/ParametersTest.php
+++ b/tests/ParametersTest.php
@@ -99,7 +99,7 @@ final class ParametersTest extends StructuredFieldTestCase
         self::assertFalse($deletedInstance->has('boolean'));
         self::assertFalse($deletedInstance->hasPair(1));
 
-        $instance = new class () implements StructuredFieldAccess {
+        $instance = new class () implements StructuredFieldProvider {
             public function toStructuredField(): StructuredField
             {
                 return Item::fromString('BarBaz');


### PR DESCRIPTION
The interface allow adding custom structured field. If a class implement the interface it will be able to be added to each DataType with ease.

For instance you will be able to do the following:

```php
$myObject = new class () implements StructuredFieldAccess {
    public function toStructuredField(): StructuredField
    {
        return Item::new(Token::fromString('babayaga'));
    }
};


$instance = InnerList::fromAssociative([$myObject, 'a', true], ['a' => true]);
echo $instance->toHttpValue();
// prints '(babayaga "a" ?1);a' 
```

On `StructuredField` creation the `toStructuredField` method is called and its return value is
used and store in place of the `$myObject` instance.